### PR TITLE
Migration to Null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.4.0-nullsafety.0]
+
+* Migrating to null safety
+
 ## [1.3.2] - 2020/08/13
 
 * Type parameters rename (clean-code).

--- a/lib/src/cache.dart
+++ b/lib/src/cache.dart
@@ -7,13 +7,13 @@ typedef R1_0<Result> = Result Function();
 typedef F1_0<Result, State1> = R1_0<Result> Function(State1);
 
 /// Cache for 1 immutable state, and no parameters.
-F1_0<Result, State1> cache1_0<Result, State1>(F1_0<Result, State1> f) {
-  WeakContainer _s1;
-  WeakMap<State1, Result> weakMap;
+F1_0<Result?, State1> cache1_0<Result, State1>(F1_0<Result, State1> f) {
+  WeakContainer? _s1;
+  late WeakMap<State1, Result> weakMap;
 
   return (State1 s1) {
     return () {
-      if (_s1 == null || !_s1.contains(s1)) {
+      if (_s1 == null || !_s1!.contains(s1)) {
         weakMap = WeakMap();
         _s1 = WeakContainer(s1);
         var result = f(s1)();
@@ -34,15 +34,15 @@ typedef R1_1<Result, Param1> = Result Function(Param1);
 typedef F1_1<Result, State1, Param1> = R1_1<Result, Param1> Function(State1);
 
 /// Cache for 1 immutable state, and 1 parameter.
-F1_1<Result, State1, Param1> cache1_1<Result, State1, Param1>(
+F1_1<Result?, State1, Param1> cache1_1<Result, State1, Param1>(
   F1_1<Result, State1, Param1> f,
 ) {
-  WeakContainer _s1;
-  WeakMap<State1, Map<Param1, Result>> weakMap;
+  WeakContainer? _s1;
+  late WeakMap<State1, Map<Param1, Result>> weakMap;
 
   return (State1 s1) {
     return (Param1 p1) {
-      if (_s1 == null || !_s1.contains(s1)) {
+      if (_s1 == null || !_s1!.contains(s1)) {
         weakMap = WeakMap();
         Map<Param1, Result> map = HashMap();
         weakMap[s1] = map;
@@ -53,8 +53,7 @@ F1_1<Result, State1, Param1> cache1_1<Result, State1, Param1>(
       }
       //
       else {
-        Map<Param1, Result> map = weakMap[s1];
-        assert(map != null);
+        Map<Param1, Result> map = weakMap[s1]!;
         if (!map.containsKey(p1)) {
           var result = f(s1)(p1);
           map[p1] = result;
@@ -77,15 +76,15 @@ typedef F1_2<Result, State1, Param1, Param2> = //
     R1_2<Result, Param1, Param2> Function(State1);
 
 /// Cache for 1 immutable state, and 2 parameters.
-F1_2<Result, State1, Param1, Param2> cache1_2<Result, State1, Param1, Param2>(
+F1_2<Result?, State1, Param1, Param2> cache1_2<Result, State1, Param1, Param2>(
     F1_2<Result, State1, Param1, Param2> f) {
-  WeakContainer _s1;
-  WeakMap<State1, Map<_Pair<Param1, Param2>, Result>> weakMap;
+  WeakContainer? _s1;
+  late WeakMap<State1, Map<_Pair<Param1, Param2>, Result>> weakMap;
 
   return (State1 s1) {
     return (Param1 p1, Param2 p2) {
       var parP = _Pair(p1, p2);
-      if (_s1 == null || !_s1.contains(s1)) {
+      if (_s1 == null || !_s1!.contains(s1)) {
         weakMap = WeakMap();
         Map<_Pair<Param1, Param2>, Result> map = HashMap();
         weakMap[s1] = map;
@@ -96,8 +95,7 @@ F1_2<Result, State1, Param1, Param2> cache1_2<Result, State1, Param1, Param2>(
       }
       //
       else {
-        Map<_Pair<Param1, Param2>, Result> map = weakMap[s1];
-        assert(map != null);
+        Map<_Pair<Param1, Param2>, Result> map = weakMap[s1]!;
         if (!map.containsKey(parP)) {
           var result = f(s1)(p1, p2);
           map[parP] = result;
@@ -115,19 +113,19 @@ typedef R2_0<Result> = Result Function();
 typedef F2_0<Result, State1, State2> = R2_0<Result> Function(State1, State2);
 
 /// Cache for 2 immutable states, and no parameters.
-F2_0<Result, State1, State2> cache2_0<Result, State1, State2>(
+F2_0<Result?, State1, State2> cache2_0<Result, State1, State2>(
   F2_0<Result, State1, State2> f,
 ) {
-  WeakContainer _s1, _s2;
-  WeakMap<State1, WeakMap<State2, Result>> weakMap1;
+  WeakContainer? _s1, _s2;
+  late WeakMap<State1, WeakMap<State2, Result>> weakMap1;
   WeakMap<State2, Result> weakMap2;
 
   return (State1 s1, State2 s2) {
     return () {
       if (_s1 == null ||
           _s2 == null || //
-          !_s1.contains(s1) ||
-          !_s2.contains(s2)) {
+          !_s1!.contains(s1) ||
+          !_s2!.contains(s2)) {
         _s1 = WeakContainer(s1);
         _s2 = WeakContainer(s2);
 
@@ -140,7 +138,7 @@ F2_0<Result, State1, State2> cache2_0<Result, State1, State2>(
       }
       //
       else {
-        return weakMap1[s1][s2];
+        return weakMap1[s1]![s2];
       }
     };
   };
@@ -155,18 +153,18 @@ typedef F2_1<Result, State1, State2, Param1> = R2_1<Result, Param1> Function(
 );
 
 /// Cache for 2 immutable states, and 1 parameter.
-F2_1<Result, State1, State2, Param1> cache2_1<Result, State1, State2, Param1>(
+F2_1<Result?, State1, State2, Param1> cache2_1<Result, State1, State2, Param1>(
     F2_1<Result, State1, State2, Param1> f) {
-  WeakContainer _s1, _s2;
-  WeakMap<State1, WeakMap<State2, Map<Param1, Result>>> weakMap1;
+  WeakContainer? _s1, _s2;
+  late WeakMap<State1, WeakMap<State2, Map<Param1, Result>>> weakMap1;
   WeakMap<State2, Map<Param1, Result>> weakMap2;
 
   return (State1 s1, State2 s2) {
     return (Param1 p1) {
       if (_s1 == null ||
           _s2 == null || //
-          !_s1.contains(s1) ||
-          !_s2.contains(s2)) {
+          !_s1!.contains(s1) ||
+          !_s2!.contains(s2)) {
         _s1 = WeakContainer(s1);
         _s2 = WeakContainer(s2);
 
@@ -181,8 +179,7 @@ F2_1<Result, State1, State2, Param1> cache2_1<Result, State1, State2, Param1>(
       }
       //
       else {
-        Map<Param1, Result> map = weakMap1[s1][s2];
-        assert(map != null);
+        Map<Param1, Result> map = weakMap1[s1]![s2]!;
         if (!map.containsKey(p1)) {
           var result = f(s1, s2)(p1);
           map[p1] = result;
@@ -204,17 +201,17 @@ typedef F2_2<Result, State1, State2, Param1, Param2> = //
     R2_2<Result, Param1, Param2> Function(State1, State2);
 
 /// Cache for 2 immutable states, and 2 parameters.
-F2_2<Result, State1, State2, Param1, Param2> //
+F2_2<Result?, State1, State2, Param1, Param2> //
     cache2_2<Result, State1, State2, Param1, Param2>(
         F2_2<Result, State1, State2, Param1, Param2> f) {
-  WeakContainer _s1, _s2;
-  WeakMap<State1, WeakMap<State2, Map<_Pair<Param1, Param2>, Result>>> weakMap1;
+  WeakContainer? _s1, _s2;
+  late WeakMap<State1, WeakMap<State2, Map<_Pair<Param1, Param2>, Result>>> weakMap1;
   WeakMap<State2, Map<_Pair<Param1, Param2>, Result>> weakMap2;
 
   return (State1 s1, State2 s2) {
     return (Param1 p1, Param2 p2) {
       var par = _Pair(p1, p2);
-      if (_s1 == null || !_s1.contains(s1) || !_s2.contains(s2)) {
+      if (_s1 == null || !_s1!.contains(s1) || !_s2!.contains(s2)) {
         _s1 = WeakContainer(s1);
         _s2 = WeakContainer(s2);
 
@@ -229,8 +226,7 @@ F2_2<Result, State1, State2, Param1, Param2> //
       }
       //
       else {
-        Map<_Pair<Param1, Param2>, Result> map = weakMap1[s1][s2];
-        assert(map != null);
+        Map<_Pair<Param1, Param2>, Result> map = weakMap1[s1]![s2]!;
         if (!map.containsKey(par)) {
           var result = f(s1, s2)(p1, p2);
           map[par] = result;
@@ -252,10 +248,10 @@ typedef F3_0<Result, State1, State2, State3> = //
     R3_0<Result> Function(State1, State2, State3);
 
 /// Cache for 3 immutable states, and no parameters.
-F3_0<Result, State1, State2, State3> cache3_0<Result, State1, State2, State3>(
+F3_0<Result?, State1, State2, State3> cache3_0<Result, State1, State2, State3>(
     F3_0<Result, State1, State2, State3> f) {
-  WeakContainer _s1, _s2, _s3;
-  WeakMap<State1, WeakMap<State2, WeakMap<State3, Result>>> weakMap1;
+  WeakContainer? _s1, _s2, _s3;
+  late WeakMap<State1, WeakMap<State2, WeakMap<State3, Result>>> weakMap1;
   WeakMap<State2, WeakMap<State3, Result>> weakMap2;
   WeakMap<State3, Result> weakMap3;
 
@@ -264,9 +260,9 @@ F3_0<Result, State1, State2, State3> cache3_0<Result, State1, State2, State3>(
       if (_s1 == null ||
           _s2 == null ||
           _s3 == null || //
-          !_s1.contains(s1) ||
-          !_s2.contains(s2) ||
-          !_s3.contains(s3)) {
+          !_s1!.contains(s1) ||
+          !_s2!.contains(s2) ||
+          !_s3!.contains(s3)) {
         _s1 = WeakContainer(s1);
         _s2 = WeakContainer(s2);
         _s3 = WeakContainer(s3);
@@ -282,7 +278,7 @@ F3_0<Result, State1, State2, State3> cache3_0<Result, State1, State2, State3>(
       }
       //
       else {
-        return weakMap1[s1][s2][s3];
+        return weakMap1[s1]![s2]![s3];
       }
     };
   };

--- a/lib/src/weak_container.dart
+++ b/lib/src/weak_container.dart
@@ -16,16 +16,16 @@
 /// the weak-container will NOT prevent `obj` to be garbage-collected.
 ///
 class WeakContainer {
-  Expando _expando;
-  Object _value;
+  Expando? _expando;
+  Object? _value;
   bool _isNull;
 
-  WeakContainer(Object value)
-      : _expando = _allowedInExpando(value) ? _createExpando(value) : null,
+  WeakContainer(Object? value)
+      : _expando = _allowedInExpando(value) ? _createExpando(value!) : null,
         _value = _allowedInExpando(value) ? null : value,
         _isNull = (value == null);
 
-  bool contains(Object value) {
+  bool contains(Object? value) {
     if (value == null) {
       return _isNull;
     } else {
@@ -34,7 +34,7 @@ class WeakContainer {
       } else {
         return (_expando != null && //
             _allowedInExpando(value) &&
-            _expando[value] == true);
+            _expando![value] == true);
       }
     }
   }
@@ -52,6 +52,6 @@ class WeakContainer {
     return expando;
   }
 
-  static bool _allowedInExpando(Object value) =>
+  static bool _allowedInExpando(Object? value) =>
       value is! String && value is! num && value is! bool && value != null;
 }

--- a/lib/src/weak_map.dart
+++ b/lib/src/weak_map.dart
@@ -1,5 +1,3 @@
-import 'package:meta/meta.dart';
-
 /// A WeakMap lets you garbage-collect its keys.
 /// Please note: The **[key]** can be garbage-collected, not the [value].
 ///

--- a/lib/src/weak_map.dart
+++ b/lib/src/weak_map.dart
@@ -45,22 +45,22 @@ import 'package:meta/meta.dart';
 ///
 class WeakMap<K, V> {
   final Map<K, V> _map;
-  Expando<V> _expando;
+  Expando _expando;
 
   WeakMap()
       : _map = {},
         _expando = Expando();
 
-  static bool _allowedInExpando(Object value) =>
+  static bool _allowedInExpando(Object? value) =>
       value is! String && value is! num && value is! bool && value != null;
 
   void operator []=(K key, V value) => add(key: key, value: value);
 
-  V operator [](K key) => get(key);
+  V? operator [](K key) => get(key);
 
-  void add({@required K key, @required V value}) {
+  void add({required K key, required V value}) {
     if (_allowedInExpando(key)) {
-      _expando[key] = value;
+      _expando[key!] = value;
     } else {
       _map[key] = value;
     }
@@ -68,16 +68,16 @@ class WeakMap<K, V> {
 
   bool contains(K key) => get(key) != null;
 
-  V get(K key) => _map.containsKey(key)
+  V? get(K key) => _map.containsKey(key)
       ? //
       _map[key]
-      : (_allowedInExpando(key) ? _expando[key] : null);
+      : (_allowedInExpando(key) ? _expando[key!] as V : null);
 
   void remove(K key) {
     _map.remove(key);
 
     if (_allowedInExpando(key)) {
-      _expando[key] = null;
+      _expando[key!] = null;
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,9 +7,6 @@ homepage: https://github.com/marcglasberg/weak_map
 environment:
   sdk: '>=2.12.0-29.10.beta <3.0.0'
 
-dependencies:
-  meta: ^1.3.0-nullsafety
-
 dev_dependencies:
   test: ^1.16.0-nullsafety
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,17 +1,17 @@
 name: weak_map
 description: WeakMap is a map of key/value pairs in which the keys are weakly referenced. WeakContainer lets you check if some object is the same you had before.
-version: 1.3.2
+version: 1.4.0-nullsafety.0
 author: Marcelo Glasberg <marcglasberg@gmail.com>
 homepage: https://github.com/marcglasberg/weak_map
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: '>=2.12.0-29.10.beta <3.0.0'
 
 dependencies:
-  meta: ^1.1.8
+  meta: ^1.3.0-nullsafety
 
 dev_dependencies:
-  test: 1.14.3
+  test: ^1.16.0-nullsafety
 
 
 

--- a/test/cache_test.dart
+++ b/test/cache_test.dart
@@ -98,8 +98,12 @@ void main() {
               .toList();
         });
 
+    // With no other changes except
+    // flutter channel stable 1.22.5 => flutter channel beta  1.24.0-10.2.pre
+    // (Dart version 2.10.4)         => (Dart version 2.12.0 (build 2.12.0-29.10.beta))
+    // suddenly this isTrue
     String otherA = "a" ""; // Concatenate.
-    expect(identical("a", otherA), isFalse);
+    expect(identical("a", otherA), isTrue);
 
     var memoA1 = selector(stateNames)("A", "a");
     var memoA2 = selector(stateNames)("A", otherA);


### PR DESCRIPTION
#3 

while on the migration I came accross the following issue in [cache_test.dart](test/cache_test.dart) :
```
    // With no other changes except 
    // flutter channel stable 1.22.5 => flutter channel beta  1.24.0-10.2.pre
    // (Dart version 2.10.4)         => (Dart version 2.12.0 (build 2.12.0-29.10.beta))
    // suddenly this no longer isFalse but isTrue

    String otherA = "a" ""; // Concatenate.
    expect(identical("a", otherA), isFalse);
```